### PR TITLE
Update class-boldgrid-editor-layout.php

### DIFF
--- a/includes/media/class-boldgrid-editor-layout.php
+++ b/includes/media/class-boldgrid-editor-layout.php
@@ -147,6 +147,70 @@ class Boldgrid_Layout extends Boldgrid_Editor_Media_Tab {
 		return $row_content;
 	}
 
+	    /**
+
+     * Filters out all nested rows from gridblocks
+
+     *
+
+     * @param array $row_content
+
+     * @since 1.0.5
+
+     * @return array $updated_row_content
+
+     */
+
+    public static function remove_nested_rows( $row_content ) {
+
+        /**
+
+         * Check if given row is nested
+
+         */
+
+        $nested_row_check = function ( $row ) use($row_content ) {
+
+            $is_nested_row = false;
+
+            
+
+            foreach ( $row_content as $existing_row ) {
+
+                if ( false == strpos( $existing_row['html'], $row_content['html'] ) &&
+
+                     $existing_row['html'] != $row['html'] ) {
+
+                    $is_nested_row = true;
+
+                    break;
+
+                }
+
+            }
+
+            return $is_nested_row;
+
+        };
+
+        // Move all rows that are not nested into a new array
+
+        $updated_row_content = array ();
+
+        foreach ( $row_content as $row ) {
+
+            if ( false == $nested_row_check( $row ) ) {
+
+                $updated_row_content[] = $row;
+
+            }
+
+        }
+
+        return $updated_row_content;
+
+    }
+
 	/**
 	 * Remove all duplicate gridblocks from array
 	 *
@@ -310,6 +374,7 @@ class Boldgrid_Layout extends Boldgrid_Editor_Media_Tab {
 		// Update GridBlock array
 		$row_content = self::sort_gridblocks( $row_content );
 		$row_content = self::remove_duplicate_gridblocks( $row_content );
+		$row_content = self::remove_nested_rows( $row_content ); 
 
 		return $row_content;
 	}


### PR DESCRIPTION
By removing remove_nested_rows function, this breaks *some* editors.  While the old function was throwing an error due to the strpos (needle) being empty/null;  This should fix the issue, with the loading of the editor and also fix the error message