### PR TITLE
Adding Orange User Group support links to the rating promt and help tab.

### DIFF
--- a/includes/Rating/config.php
+++ b/includes/Rating/config.php
@@ -60,6 +60,11 @@ $default_prompt = array(
 					'snooze' => WEEK_IN_SECONDS,
 					'slide'  => 'maybe_later',
 				),
+				'user_group'          => array(
+					'text'   => __( 'Maybe later, I\'d first like to post a question to the Team Orange User Group.', 'boldgrid-editor' ),
+					'snooze' => WEEK_IN_SECONDS,
+					'link'   => 'https://www.facebook.com/groups/BGTeamOrange',
+				),
 				'already_did'         => array(
 					'text'  => __( 'I already did', 'boldgrid-editor' ),
 					'slide' => 'already_did',

--- a/pages/help-tab.html
+++ b/pages/help-tab.html
@@ -11,7 +11,7 @@
     Any additional controls available for that item will appear in a Drop Tab at the top of your editor. Try clicking on
     any of the available controls to explore the options available to you.
 </p>
-<h4>For more information on using the Post and Page Builder please visit the BoldGrid support site:
-    <a href="https://www.boldgrid.com/support/boldgrid-post-and-page-builder/?source=boldgrid-editor_admin-help-tab"
-     target="_blank">BoldGrid Page &amp; Post Editor</a>
+<h4>
+	For more information on using the Post and Page Builder please visit the BoldGrid support site: <a href="https://www.boldgrid.com/support/boldgrid-post-and-page-builder/?source=boldgrid-editor_admin-help-tab" target="_blank">BoldGrid Page &amp; Post Editor</a>.
+	We also suggest joining our <a href="https://www.facebook.com/groups/BGTeamOrange" target="_blank">Team Orange User Group community</a> for free support, tips and tricks.
 </h4>

--- a/readme.txt
+++ b/readme.txt
@@ -139,6 +139,12 @@ WordPress Editor.
 
 == Changelog ==
 
+= 1.10.1 In progress =
+
+Release Date: tbd
+
+* Update: Adding Orange User Group support links to the rating promt and help tab.
+
 = 1.10.0 =
 
 Release Date: February 14, 2019


### PR DESCRIPTION
# Testing Instructions

**New link added to rating prompt.**
1. [ ] delete_option( 'bglib_rating_prompt' );
1. [ ] within includes/Rating/config.php, change the block_install threshold to 1 on line 130'sh
1. [ ] Add a block to any page, and publish. When the page reloads, you should see the rating prompt at the top of the page. Option 3 links to the Team Orange User Group. The link works as expected.

**New link added to help tab.**
1. [ ] While editing a page, click the help tab at the top right.
1. [ ] At the bottom of the Post and Page Builder tab, you should see a link to the Team Orange User Group. Ensure verbiage sounds good and link works as expected.