### PR TITLE
check for theme name by Author and child theme by parent.  fixes #79

### DIFF
--- a/includes/class-boldgrid-editor-theme.php
+++ b/includes/class-boldgrid-editor-theme.php
@@ -77,7 +77,6 @@ class Boldgrid_Editor_Theme {
 
 			if ( strpos( $author, 'boldgrid' ) !== false ) {
 				$current_boldgrid_theme = $current_theme->get( 'Name' );
-				var_dump( $current_boldgrid_theme ); die;
 			} elseif ( is_child_theme() ) {
 				$parent = $current_theme->get( 'Template' );
 
@@ -86,7 +85,7 @@ class Boldgrid_Editor_Theme {
 				$author = strtolower( $author );
 
 				if ( strpos( $author, 'boldgrid' ) !== false ) {
-					$current_boldgrid_theme = $parent->get( 'Name' );
+					$current_boldgrid_theme = $current_theme->get( 'Name' );
 				}
 			}
 		}

--- a/includes/class-boldgrid-editor-theme.php
+++ b/includes/class-boldgrid-editor-theme.php
@@ -71,12 +71,27 @@ class Boldgrid_Editor_Theme {
 
 		$current_theme = $wp_theme;
 
-		if ( is_a( $current_theme, 'WP_Theme' ) &&
-			strpos( $current_theme->get( 'TextDomain' ), 'boldgrid' ) !== false ) {
-				$current_boldgrid_theme = $current_theme->get( 'Name' );
-			}
+		if ( is_a( $current_theme, 'WP_Theme' ) ) {
+			$author = $current_theme->get( 'Author' );
+			$author = strtolower( $author );
 
-			return $current_boldgrid_theme;
+			if ( strpos( $author, 'boldgrid' ) !== false ) {
+				$current_boldgrid_theme = $current_theme->get( 'Name' );
+				var_dump( $current_boldgrid_theme ); die;
+			} elseif ( is_child_theme() ) {
+				$parent = $current_theme->get( 'Template' );
+
+				$parent = wp_get_theme( $parent );
+				$author = $parent->get( 'Author' );
+				$author = strtolower( $author );
+
+				if ( strpos( $author, 'boldgrid' ) !== false ) {
+					$current_boldgrid_theme = $parent->get( 'Name' );
+				}
+			}
+		}
+
+		return $current_boldgrid_theme;
 	}
 
 	/**


### PR DESCRIPTION
updates method to check for boldgrid theme name to stop using textdomains.  This will allow people making child themes to support the editor not have to include their theme name as "BoldGrid Somename" with a textdomain `boldgrid-somename`