### PR TITLE
Fixing undefined constant error

### DIFF
--- a/includes/class-boldgrid-editor-theme.php
+++ b/includes/class-boldgrid-editor-theme.php
@@ -77,7 +77,7 @@ class Boldgrid_Editor_Theme {
 
 			if ( strpos( $author, 'boldgrid' ) !== false ) {
 				$current_boldgrid_theme = $current_theme->get( 'Name' );
-			} elseif ( is_child_theme() ) {
+			} elseif ( get_template_directory() !== get_stylesheet_directory() ) {
 				$parent = $current_theme->get( 'Template' );
 
 				$parent = wp_get_theme( $parent );


### PR DESCRIPTION
Error

`{type: "notice", message: "Use of undefined constant TEMPLATEPATH - assumed 'TEMPLATEPATH'", file: "wp-includes/theme.php", line: 152,
stack: Array(6), …}
component: "Plugin: post-and-page-builder"
file: "wp-includes/theme.php"
line: 152
message: "Use of undefined constant TEMPLATEPATH - assumed 'TEMPLATEPATH'"
stack: Array(6)
0: "is_child_theme()"
1: "Boldgrid_Editor_Theme::get_boldgrid_theme_name()"
2: "Boldgrid_Editor_Theme::is_editing_boldgrid_theme()"
3: "Boldgrid_Editor->__construct()"
4: "boldgrid_editor_setup()"
5: "do_action('setup_theme')"`



WP Code:
https://core.trac.wordpress.org/browser/tags/5.1.1/src/wp-includes/theme.php#L151 

Constants defined here: 
https://core.trac.wordpress.org/browser/tags/5.1.1/src/wp-settings.php#L446 a couple lines after setup theme
