### PR TITLE
fix mobile hover boxes

### DIFF
--- a/assets/js/builder/controls/element/background.js
+++ b/assets/js/builder/controls/element/background.js
@@ -389,9 +389,11 @@ BOLDGRID.EDITOR.CONTROLS = BOLDGRID.EDITOR.CONTROLS || {};
 				}:hover {background-size: cover !important; background-position: 50%, 50% !important;}`;
 				self._addHeadingStyle( hoverBgClassName + '-bg-size', css );
 
-				css = '@media (hover: none) {';
-				css += `.${hoverBgClassName} { background-image: url('${hoverBgUrl}') !important; } }`;
-				self._addHeadingStyle( hoverBgClassName + '-mobie-image', css );
+				css = '@media screen and (max-width: 991px) {';
+				css += `.${hoverBgClassName}.hover-mobile-bg { background-image: url('${
+					hoverBgUrl
+				}') !important; } }`;
+				self._addHeadingStyle( hoverBgClassName + '-mobile-image', css );
 			} );
 		},
 

--- a/assets/js/public.js
+++ b/assets/js/public.js
@@ -411,8 +411,8 @@ class Public {
 			}
 			css += '}';
 
-			css  += '@media (hover: none) {';
-			css += `.${hoverBoxClass} { background-image: url('${hoverBgUrl}') !important; } }`;
+			css  += '@media screen and (max-width: 991px) {';
+			css += `.${hoverBoxClass}.hover-mobile-bg { background-image: url('${hoverBgUrl}') !important; } }`;
 		} );
 		$( 'head' ).append( `<style id="bg-hoverboxes-css">${css}</style>` );
 	}


### PR DESCRIPTION
resolves #448 

# Testing Instructions #

1. Install the test zip attached or use the [one-click-install link](https://www.boldgrid.com/central/cloud-wordpress/try?plugins=https://github.com/BoldGrid/post-and-page-builder/files/9576806/post-and-page-builder-1.21.2.zip).

[post-and-page-builder-1.21.2.zip](https://github.com/BoldGrid/post-and-page-builder/files/9576806/post-and-page-builder-1.21.2.zip)


2. Create a post where one or more columns have a standard background image and a different hover image.
3. Set the hover image to 'Show hover background on mobile'
4. Add a child element to the column, and set the hover effects to 'Show on Hover'
5. Save the post, and view it on a mobile device ( phone or tablet )
6. Ensure that the hover image is shown for the column, and not the standard image on a mobile device.
7. Ensure that the child element within that column is shown at all times on a mobile device