### PR TITLE
update boldgrid/controls for line-height fix

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -99,7 +99,7 @@
 
 "@boldgrid/controls@https://github.com/BoldGrid/controls#outline-control":
   version "0.13.1"
-  resolved "https://github.com/BoldGrid/controls#eb6a7711d451a6f007789f665af167b9be1fa362"
+  resolved "https://github.com/BoldGrid/controls#90cd9b641c90ad38433d8c39bfa938b7c3a965fd"
   dependencies:
     "@boldgrid/components" "^2.16.8"
     Buttons "https://github.com/alexwolfe/Buttons"


### PR DESCRIPTION
Resolves #415 

### Testing Instructions ###
1. Install Post and Page Builder using the following link: 
[post-and-page-builder.zip](https://github.com/BoldGrid/post-and-page-builder/files/9759087/post-and-page-builder.zip)
2. Create or Edit a post with text.
3. Edit the text properties for a text component.
4. ensure that the 'Line Height' slider is capable of going from 1-100px.