### PR TITLE
Issues 459 & 512 - Fix border issues with newly added components

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -94,7 +94,7 @@
 
 "@boldgrid/controls@https://github.com/BoldGrid/controls#outline-control":
   version "0.13.1"
-  resolved "https://github.com/BoldGrid/controls#90cd9b641c90ad38433d8c39bfa938b7c3a965fd"
+  resolved "https://github.com/BoldGrid/controls#1f299be41f23eec4aaebeefd1cef4b27892ba62a"
   dependencies:
     "@boldgrid/components" "^2.16.8"
     Buttons "https://github.com/alexwolfe/Buttons"


### PR DESCRIPTION
ISSUE: Resolves #459 
           Resolves #512 

NOTE: Both issues were caused by the same root issue, that the style `border-width:0px` was being added to new elements unnecessarily. Therefore, both issues are being resolved in the same PR. This issue was being caused by the @boldgrid/controls repository. See [commit #1f299be](https://github.com/BoldGrid/controls/commit/1f299be41f23eec4aaebeefd1cef4b27892ba62a)

PROJECT: [PPB 1.23.1](https://github.com/orgs/BoldGrid/projects/14/views/11)

# Fix border issues with newly added components #

## Test Files ##

[post-and-page-builder.zip](https://github.com/BoldGrid/post-and-page-builder/files/11192282/post-and-page-builder.zip)

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Add a new component. Specifically ensure you test with Buttons, as these were one specifically reported issue.
3. Ensure that the new component does not have the `border-width: 0px` inline style added. If testing primary or secondary theme buttons, skip steps 4-6.
4. Open the advanced control panel for the new element, and go to the 'border' controls
5. Ensure that the border style is shown as 'None'
6. Set a border style, and a border width.
7. Save & publish.
8. View the page on the front end and ensure the border is visible.
9. When testing a button, if the button border is not visible ( due to the button styling set in the Crio Customizer ), open the customizer, and configure the associated button class ( primary or secondary ) to show the border, and ensure that it shows as expected.