### PR TITLE
add nonce validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Official Download Link:
 
 **Requires at least:** 4.7
 
-**Tested up to:** 6.2
+**Tested up to:** 6.3
 
 **License:** GPLv2 or later
 

--- a/assets/js/forms/default-editor/form.js
+++ b/assets/js/forms/default-editor/form.js
@@ -48,6 +48,7 @@ export class Form {
 		return `
 			<form method="POST" class="bgppb-default-editor">
 				<input type="hidden" name="bgppb-form-action" value="default_editor">
+				<input type="hidden" name="bgppb-form-action-nonce" value="${BoldgridEditor.bgppb_form_action_nonce}">
 				<h2>Preferred Editor</h2>
 				<p>
 					Choose the preferred way to edit your content.

--- a/includes/View/Settings.php
+++ b/includes/View/Settings.php
@@ -171,8 +171,6 @@ class Settings {
 		if ( wp_verify_nonce( $_REQUEST['bgppb-form-action-nonce'], 'bgppb_form_action_nonce' ) ) {
 			$action = sanitize_text_field( $_REQUEST['bgppb-form-action'] );
 			do_action( 'bgppb_form_' . $action );
-		} else {
-			return;
 		}
 	}
 

--- a/includes/View/Settings.php
+++ b/includes/View/Settings.php
@@ -151,14 +151,36 @@ class Settings {
 	 * @since 1.9.0
 	 */
 	public function formActionRoute() {
-		if ( ! empty( $_REQUEST['bgppb-form-action'] ) && current_user_can( 'manage_options' ) ) {
+
+		// User must be authenticated
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// Only handle ppb form actions
+		if ( empty( $_REQUEST['bgppb-form-action'] ) ) {
+			return;
+		}
+
+		// Only accept forms with a nonce
+		if ( empty( $_REQUEST['bgppb-form-action-nonce'] ) ) {
+			return;
+		}
+
+		// Validate the nonce
+		if ( wp_verify_nonce( $_REQUEST['bgppb-form-action-nonce'], 'bgppb_form_action_nonce' ) ) {
 			$action = sanitize_text_field( $_REQUEST['bgppb-form-action'] );
 			do_action( 'bgppb_form_' . $action );
+		} else {
+			return;
 		}
 	}
 
 	/**
 	 * Handle the form submission for default editor.
+	 *
+	 * This action is called by the formActionRoute method.
+	 * Nonce validation is handled by the formActionRoute method.
 	 *
 	 * @since 1.9.0
 	 */

--- a/includes/class-boldgrid-editor-assets.php
+++ b/includes/class-boldgrid-editor-assets.php
@@ -447,14 +447,15 @@ class Boldgrid_Editor_Assets {
 	 * @return array JS Variables.
 	 */
 	public function get_shared_vars() {
-		return [
-			'plugin_url' => plugins_url( '', BOLDGRID_EDITOR_ENTRY ),
-			'plugin_configs' => Boldgrid_Editor_Service::get( 'config' ),
-			'globalSettings' => Boldgrid_Editor_Service::get( 'settings' )->get_all(),
-			'customPostTypes' => Boldgrid_Editor_Service::get( 'settings' )->get_custom_post_types(),
-			'pluginVersion' => BOLDGRID_EDITOR_VERSION,
-			'editor_override' => Boldgrid_Editor_Setting::get_editor_override(),
-		];
+		return array(
+			'bgppb_form_action_nonce' => wp_create_nonce( 'bgppb_form_action_nonce' ),
+			'plugin_url'              => plugins_url( '', BOLDGRID_EDITOR_ENTRY ),
+			'plugin_configs'          => Boldgrid_Editor_Service::get( 'config' ),
+			'globalSettings'          => Boldgrid_Editor_Service::get( 'settings' )->get_all(),
+			'customPostTypes'         => Boldgrid_Editor_Service::get( 'settings' )->get_custom_post_types(),
+			'pluginVersion'           => BOLDGRID_EDITOR_VERSION,
+			'editor_override'         => Boldgrid_Editor_Setting::get_editor_override(),
+		);
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "boldgrid-editor",
-	"version": "1.24.1",
+	"version": "1.24.2",
 	"description": "Post and Page Builder is a standalone plugin which adds functionality to the existing TinyMCE Editor.",
 	"main": "assets/js/editor.js",
 	"scripts": {

--- a/post-and-page-builder.php
+++ b/post-and-page-builder.php
@@ -3,7 +3,7 @@
  * Plugin Name: Post and Page Builder
  * Plugin URI: https://www.boldgrid.com/boldgrid-editor/?utm_source=ppb-wp-repo&utm_medium=plugin-uri&utm_campaign=ppb
  * Description: Customized drag and drop editing for posts and pages. The Post and Page Builder adds functionality to the existing TinyMCE Editor to give you easier control over your content.
- * Version: 1.24.1
+ * Version: 1.24.2
  * Author: BoldGrid <support@boldgrid.com>
  * Author URI: https://www.boldgrid.com/?utm_source=ppb-wp-repo&utm_medium=author-uri&utm_campaign=ppb
  * Text Domain: boldgrid-editor

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: boldgrid, rramo012, imh_brad, joemoto, timph, bgnicolepaschen, jamesros161
 Tags: boldgrid, page builder, drag and drop, tinymce, editor, landing page
 Requires at least: 4.7
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 5.4
-Stable tag: 1.24.1
+Stable tag: 1.24.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -133,6 +133,9 @@ WordPress Editor.
 7. Adding Icons.
 
 == Changelog ==
+
+= 1.24.2 =
+* Security Fix: Patch CSRF vulnerability in the submitDefaultEditor function [#540](https://github.com/BoldGrid/post-and-page-builder/issues/540)
 
 = 1.24.1 =
 * Update: Update BoldGrid/Library to 2.13.11 to resolve PHP 8.2 compatibility issues.


### PR DESCRIPTION
ISSUE: Resolves #540 
# Add Nonce Validation to `formActionRoute` #

This vulnerability was reported based on the `submitDefaultEditor` method not using nonce validation. However, this method is actually called by the `formActionRoute` , therefore the nonce validation is being added there.

