### PR TITLE
resolves Tables are very wide on iOS mobile devices (12, chrome) #520

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 	},
 	"dependencies": {
 		"@babel/preset-react": "^7.22.3",
-		"@boldgrid/components": "^2.16.29",
+		"@boldgrid/components": "^2.16.30",
 		"@boldgrid/controls": "https://github.com/BoldGrid/controls#ppb-dev",
 		"@boldgrid/fourpan": "^1.1.1",
 		"@wordpress/components": "^25.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 	},
 	"dependencies": {
 		"@babel/preset-react": "^7.22.3",
-		"@boldgrid/components": "^2.16.30",
+		"@boldgrid/components": "^2.16.31",
 		"@boldgrid/controls": "https://github.com/BoldGrid/controls#ppb-dev",
 		"@boldgrid/fourpan": "^1.1.1",
 		"@wordpress/components": "^25.0.0",

--- a/post-and-page-builder.php
+++ b/post-and-page-builder.php
@@ -3,7 +3,7 @@
  * Plugin Name: Post and Page Builder
  * Plugin URI: https://www.boldgrid.com/boldgrid-editor/?utm_source=ppb-wp-repo&utm_medium=plugin-uri&utm_campaign=ppb
  * Description: Customized drag and drop editing for posts and pages. The Post and Page Builder adds functionality to the existing TinyMCE Editor to give you easier control over your content.
- * Version: 1.25.1-issue-538
+ * Version: 1.25.1
  * Author: BoldGrid <support@boldgrid.com>
  * Author URI: https://www.boldgrid.com/?utm_source=ppb-wp-repo&utm_medium=author-uri&utm_campaign=ppb
  * Text Domain: boldgrid-editor

--- a/post-and-page-builder.php
+++ b/post-and-page-builder.php
@@ -3,7 +3,7 @@
  * Plugin Name: Post and Page Builder
  * Plugin URI: https://www.boldgrid.com/boldgrid-editor/?utm_source=ppb-wp-repo&utm_medium=plugin-uri&utm_campaign=ppb
  * Description: Customized drag and drop editing for posts and pages. The Post and Page Builder adds functionality to the existing TinyMCE Editor to give you easier control over your content.
- * Version: 1.25.1
+ * Version: 1.25.0
  * Author: BoldGrid <support@boldgrid.com>
  * Author URI: https://www.boldgrid.com/?utm_source=ppb-wp-repo&utm_medium=author-uri&utm_campaign=ppb
  * Text Domain: boldgrid-editor

--- a/post-and-page-builder.php
+++ b/post-and-page-builder.php
@@ -3,7 +3,7 @@
  * Plugin Name: Post and Page Builder
  * Plugin URI: https://www.boldgrid.com/boldgrid-editor/?utm_source=ppb-wp-repo&utm_medium=plugin-uri&utm_campaign=ppb
  * Description: Customized drag and drop editing for posts and pages. The Post and Page Builder adds functionality to the existing TinyMCE Editor to give you easier control over your content.
- * Version: 1.25.0
+ * Version: 1.25.1-issue-538
  * Author: BoldGrid <support@boldgrid.com>
  * Author URI: https://www.boldgrid.com/?utm_source=ppb-wp-repo&utm_medium=author-uri&utm_campaign=ppb
  * Text Domain: boldgrid-editor

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,10 +1151,10 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@boldgrid/components@^2.16.2", "@boldgrid/components@^2.16.25", "@boldgrid/components@^2.16.30":
-  version "2.16.30"
-  resolved "https://registry.yarnpkg.com/@boldgrid/components/-/components-2.16.30.tgz#e07a8a2b961aaa742a258df9de23aac697ce4d62"
-  integrity sha512-39c8M6EMVC1h8xwFV45uOp46m6YK8p9y82K3wnyeDOtIeujuUbJ8Up2XbVw3rfFDvgviHUarPIXmd7XbSqiGzA==
+"@boldgrid/components@^2.16.2", "@boldgrid/components@^2.16.25", "@boldgrid/components@^2.16.31":
+  version "2.16.31"
+  resolved "https://registry.yarnpkg.com/@boldgrid/components/-/components-2.16.31.tgz#47b065549637d1094c877ede50969821b0f6d24e"
+  integrity sha512-e9MdsfYkDt9Tb+2lPqCAIwPoAPoIrLc534WBoDMtJlBa4lUj/vNtOPa0XWwwLQdh9e4UeEO52d+QzhFFRrEYNQ==
 
 "@boldgrid/controls@https://github.com/BoldGrid/controls#ppb-dev":
   version "0.13.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,10 +1151,10 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@boldgrid/components@^2.16.2", "@boldgrid/components@^2.16.25", "@boldgrid/components@^2.16.29":
-  version "2.16.29"
-  resolved "https://registry.yarnpkg.com/@boldgrid/components/-/components-2.16.29.tgz#bd78df832ffbfe32f76eb462885840852aeb1943"
-  integrity sha512-x9t1Xc/2ZvFSFqMfh0VkgcEmAKXrevLyIWunUSTKlqZ44/zaSfnZ34WOvWh3iRqPRMy6HVGPdcAVV+Q60Qy0Jw==
+"@boldgrid/components@^2.16.2", "@boldgrid/components@^2.16.25", "@boldgrid/components@^2.16.30":
+  version "2.16.30"
+  resolved "https://registry.yarnpkg.com/@boldgrid/components/-/components-2.16.30.tgz#e07a8a2b961aaa742a258df9de23aac697ce4d62"
+  integrity sha512-39c8M6EMVC1h8xwFV45uOp46m6YK8p9y82K3wnyeDOtIeujuUbJ8Up2XbVw3rfFDvgviHUarPIXmd7XbSqiGzA==
 
 "@boldgrid/controls@https://github.com/BoldGrid/controls#ppb-dev":
   version "0.13.1"


### PR DESCRIPTION
ISSUE: Resolves #520 

PROJECT: [#14](https://github.com/orgs/BoldGrid/projects/14/views/11)

# resolves Tables are very wide on iOS mobile devices #

## Test Files ##

[post-and-page-builder-1.25.1-issue520.zip](https://github.com/BoldGrid/post-and-page-builder/files/12937470/post-and-page-builder-1.25.1-issue520.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Create a table using PPB table designer, and ensure the 'Responsive Tables' option is checked for phones.
3. Save the page or post with the table you've created.
4. Visit the page or post using an iPhone, or using BrowserStack.
5. Ensure that the tables resize accordingly for the device.