### PR TITLE
Editor is not detecting animations on content - Issue 538

### DIFF
--- a/includes/builder/class-boldgrid-editor-builder.php
+++ b/includes/builder/class-boldgrid-editor-builder.php
@@ -245,7 +245,6 @@ class Boldgrid_Editor_Builder {
 		$paths[] = $template_path . '/hr.php';
 		$paths[] = $template_path . '/gridblock.php';
 		$paths[] = $template_path . '/information.php';
-		$paths[] = $template_path . '/background.php';
 		$paths[] = $template_path . '/background-legacy.php';
 		$paths[] = $template_path . '/box.php';
 		$paths[] = $template_path . '/panel.php';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,7 +1158,7 @@
 
 "@boldgrid/controls@https://github.com/BoldGrid/controls#ppb-dev":
   version "0.13.1"
-  resolved "https://github.com/BoldGrid/controls#f728289aa42268c78fe7450f08f229ef48ec81fc"
+  resolved "https://github.com/BoldGrid/controls#14ea608456181f0da2a24864ac7015d5afc6a229"
   dependencies:
     "@boldgrid/components" "^2.16.25"
     Buttons "https://github.com/BoldGrid/Buttons"


### PR DESCRIPTION
ISSUE: Resolves #538 

PROJECT: [#14](https://github.com/orgs/BoldGrid/projects/14/views/11)

# Editor is not detecting animations on content #

## Test Files ##

[post-and-page-builder-1.25.1-issue538.zip](https://github.com/BoldGrid/post-and-page-builder/files/12886642/post-and-page-builder-1.25.1-issue538.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Set an animation to an element.
3. Save and reload the page / post with the animation.
4. Open the animation control, and ensure that the selected animation is shown in the control.
5. Select the 'None' option for the animation control, and ensure that the animation is removed from the element.
6. Save and reload, and ensure it is still set to 'None'