### PR TITLE
Opening Advanced Controls adds a box shadow to every element #535

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,7 +1158,7 @@
 
 "@boldgrid/controls@https://github.com/BoldGrid/controls#ppb-dev":
   version "0.13.1"
-  resolved "https://github.com/BoldGrid/controls#f728289aa42268c78fe7450f08f229ef48ec81fc"
+  resolved "https://github.com/BoldGrid/controls#da576466d2cc5d0a845b1ecf156a065442991fa9"
   dependencies:
     "@boldgrid/components" "^2.16.25"
     Buttons "https://github.com/BoldGrid/Buttons"


### PR DESCRIPTION
ISSUE: Resolves #535 

PROJECT: [#14](https://github.com/orgs/BoldGrid/projects/14/views/11)

# Opening Advanced Controls adds a box shadow to every element #

## Test Files ##

[post-and-page-builder-1.25.1-issue-535.zip](https://github.com/BoldGrid/post-and-page-builder/files/12937924/post-and-page-builder-1.25.1-issue-535.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Create a new page or post.
3. Add an element of your choice that does not have a box-shadow.
4. Click on the 'Advanced Controls' option for that element.
5. Once the panel opens, inspect the element and ensure that a box-shadow inline style hasn't been added to the element.
6. Add a box-shadow to the element, and ensure it is added correctly.