### PR TITLE
fix neutral colors not being removed from elements

### DIFF
--- a/assets/js/builder/controls/color.js
+++ b/assets/js/builder/controls/color.js
@@ -21,7 +21,7 @@ import { Palette } from './color/palette';
 
 		transparentColors: [ 'rgba(0, 0, 0, 0)', 'transparent' ],
 
-		colorClasses: [ 'color1-color', 'color2-color', 'color3-color', 'color4-color', 'color5-color' ],
+		colorClasses: [ 'color1-color', 'color2-color', 'color3-color', 'color4-color', 'color5-color', 'color-neutral-color' ],
 
 		textContrastClasses: [
 			'color-neutral-text-default',
@@ -52,7 +52,8 @@ import { Palette } from './color/palette';
 			'color2-border-color',
 			'color3-border-color',
 			'color4-border-color',
-			'color5-border-color'
+			'color5-border-color',
+			'color-neutral-border-color'
 		],
 
 		outlineColorClasses: [
@@ -60,7 +61,8 @@ import { Palette } from './color/palette';
 			'color2-outline-color',
 			'color3-outline-color',
 			'color4-outline-color',
-			'color5-outline-color'
+			'color5-outline-color',
+			'color-neutral-outline-color'
 		],
 
 		customColors: BoldgridEditor.saved_colors,


### PR DESCRIPTION
ISSUE: Resolves #527 

PROJECT: [#14](https://github.com/orgs/BoldGrid/projects/14/views/11)

# Color Neutral doesn't get removed when a new color is selected #

## Test Files ##

[post-and-page-builder-1.25.1-issue-527.zip](https://github.com/BoldGrid/post-and-page-builder/files/12938153/post-and-page-builder-1.25.1-issue-527.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Change the font color of an element to the neutral theme color ( last color in the palette )
3. Change the font color of that same element to some other theme color ( 1, 2, 3, etc )
4. Inspect the element and ensure that the 'color-neutral-color' class was removed from the element and the color of the text accurately reflects the chosen palette color.
5. Repeat steps 2 - 4 but instead of font color, change the outline color, and the border color.