### PR TITLE
Tables - color palette borders do not stay on page save #546

### DIFF
--- a/assets/js/builder/controls/generic/table-borders.js
+++ b/assets/js/builder/controls/generic/table-borders.js
@@ -250,14 +250,26 @@ import template from '../../../../../includes/template/customize/table-borders.h
 				let nodes = $target.find( nodeTypes );
 				nodes.each( function() {
 					var $this = $( this );
-					$this.css( `border-right-${styleSuffix}`, value );
-					$this.css( `border-left-${styleSuffix}`, value );
+
+					let property                            = {};
+					property[`border-right-${styleSuffix}`] = value;
+					property[`border-left-${styleSuffix}`]  = value;
+
+					window.BOLDGRID.CONTROLS.addStyles(
+						$this,
+						property
+					);
 
 					if ( ! value && 'style' === styleSuffix ) {
-						$this.css( 'border-left-width', '' );
-						$this.css( 'border-right-width', '' );
-						$this.css( 'border-left-color', '' );
-						$this.css( 'border-right-color', '' );
+						window.BOLDGRID.CONTROLS.addStyles(
+							$this,
+							{
+								'border-left-width': '',
+								'border-right-width': '',
+								'border-left-color': '',
+								'border-right-color': ''
+							}
+						);
 					}
 				} );
 			}
@@ -267,14 +279,25 @@ import template from '../../../../../includes/template/customize/table-borders.h
 				rows.each( function() {
 					var $this = $( this );
 
-					$this.find( nodeTypes ).css( `border-top-${styleSuffix}`, value );
-					$this.find( nodeTypes ).css( `border-bottom-${styleSuffix}`, value );
+					let property                             = {};
+					property[`border-top-${styleSuffix}`]    = value;
+					property[`border-bottom-${styleSuffix}`] = value;
+
+					window.BOLDGRID.CONTROLS.addStyles(
+						$this.find( nodeTypes ),
+						property
+					);
 
 					if ( ! value && 'style' === styleSuffix ) {
-						$this.find( nodeTypes ).css( 'border-top-width', '' );
-						$this.find( nodeTypes ).css( 'border-bottom-width', '' );
-						$this.find( nodeTypes ).css( 'border-top-color', '' );
-						$this.find( nodeTypes ).css( 'border-bottom-color', '' );
+						window.BOLDGRID.CONTROLS.addStyles(
+							$this.find( nodeTypes ),
+							{
+								'border-top-width': '',
+								'border-bottom-width': '',
+								'border-top-color': '',
+								'border-bottom-color': ''
+							}
+						);
 					}
 				} );
 			}
@@ -283,14 +306,21 @@ import template from '../../../../../includes/template/customize/table-borders.h
 				let nodes = $target.find( 'thead' ).find( nodeTypes );
 				nodes.each( function() {
 					var $this = $( this );
-					$this.css( `border-bottom-${styleSuffix}`, value );
-					$this.css( `border-top-${styleSuffix}`, value );
+
+					let property                             = {};
+					property[`border-top-${styleSuffix}`]    = value;
+					property[`border-bottom-${styleSuffix}`] = value;
 
 					if ( ! value && 'style' === styleSuffix ) {
-						$this.css( 'border-bottom-width', '' );
-						$this.css( 'border-bottom-color', '' );
-						$this.css( 'border-top-width', '' );
-						$this.css( 'border-top-color', '' );
+						window.BOLDGRID.CONTROLS.addStyles(
+							$this.find( nodeTypes ),
+							{
+								'border-top-width': '',
+								'border-bottom-width': '',
+								'border-top-color': '',
+								'border-bottom-color': ''
+							}
+						);
 					}
 				} );
 			}

--- a/assets/js/builder/controls/generic/table-borders.js
+++ b/assets/js/builder/controls/generic/table-borders.js
@@ -311,9 +311,14 @@ import template from '../../../../../includes/template/customize/table-borders.h
 					property[`border-top-${styleSuffix}`]    = value;
 					property[`border-bottom-${styleSuffix}`] = value;
 
+					window.BOLDGRID.CONTROLS.addStyles(
+						$this,
+						property
+					);
+
 					if ( ! value && 'style' === styleSuffix ) {
 						window.BOLDGRID.CONTROLS.addStyles(
-							$this.find( nodeTypes ),
+							$this,
 							{
 								'border-top-width': '',
 								'border-bottom-width': '',


### PR DESCRIPTION
ISSUE: Resolves #546

PROJECT: [#14](https://github.com/orgs/BoldGrid/projects/14/views/11)

# Tables - color palette borders do not stay on page save #

## Test Files ##

[post-and-page-builder-1.25.1-issue-546.zip](https://github.com/BoldGrid/post-and-page-builder/files/12949690/post-and-page-builder-1.25.1-issue-546.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Add a table to a page or post
3. Manually adjust the height of the rows in the table.
4. Set a border with a palette color to the rows on the table.
5. Save and refresh the page.
6. Ensure that the color changes save.
7. Repeat with columns and heading.