### PR TITLE
BG Connect Search - Purchased images not being replaced

### DIFF
--- a/includes/class-boldgrid-editor-crop.php
+++ b/includes/class-boldgrid-editor-crop.php
@@ -284,7 +284,7 @@ class Boldgrid_Editor_Crop {
 				)
 			);
 
-			if ( false != $asset ) {
+			if ( false !== $asset ) {
 				$crop_details['dst_width']  = $crop_details['width'];
 				$crop_details['dst_height'] = $crop_details['height'];
 
@@ -292,7 +292,8 @@ class Boldgrid_Editor_Crop {
 					'cropDetails' => $crop_details,
 					'path'        => $new_image_path,
 				);
-							// Update the asset.
+
+				// Update the asset.
 				$asset_manager->update_asset(
 					array(
 						'task'       => 'update_entire_asset',
@@ -305,11 +306,12 @@ class Boldgrid_Editor_Crop {
 		}
 
 		echo json_encode(
-			array (
-				'new_image_url' => $new_image_url,
-				'new_image_width' => $new_width,
-				'new_image_height' => $new_height
-			) );
+			array(
+				'new_image_url'    => $new_image_url,
+				'new_image_width'  => $new_width,
+				'new_image_height' => $new_height,
+			)
+		);
 
 		wp_die();
 	}

--- a/includes/class-boldgrid-editor-crop.php
+++ b/includes/class-boldgrid-editor-crop.php
@@ -273,6 +273,37 @@ class Boldgrid_Editor_Crop {
 		);
 		wp_update_attachment_metadata( $attachment_id, $dimensions );
 
+		if ( defined( 'BOLDGRID_BASE_DIR' ) ) {
+			require_once BOLDGRID_BASE_DIR . '/includes/class-boldgrid-inspirations-asset-manager.php';
+			$asset_manager = new Boldgrid_Inspirations_Asset_Manager();
+
+			$asset = $asset_manager->get_asset(
+				array(
+					'by'            => 'attachment_id',
+					'attachment_id' => $attachment_id,
+				)
+			);
+
+			if ( false != $asset ) {
+				$crop_details['dst_width']  = $crop_details['width'];
+				$crop_details['dst_height'] = $crop_details['height'];
+
+				$asset['crops'][] = array(
+					'cropDetails' => $crop_details,
+					'path'        => $new_image_path,
+				);
+							// Update the asset.
+				$asset_manager->update_asset(
+					array(
+						'task'       => 'update_entire_asset',
+						'asset_id'   => $asset['asset_id'],
+						'asset'      => $asset,
+						'asset_type' => 'image',
+					)
+				);
+			}
+		}
+
 		echo json_encode(
 			array (
 				'new_image_url' => $new_image_url,


### PR DESCRIPTION
ISSUE: Resolves #476 

PROJECT: [PPB Issues > Current Release Cycle](https://github.com/orgs/BoldGrid/projects/14/views/11)

# BG Connect Search - Purchased images not being replaced #

## Test Files ##

[post-and-page-builder-1.26.2-issue-476.zip](https://github.com/BoldGrid/post-and-page-builder/files/14043483/post-and-page-builder-1.26.2-issue-476.zip)

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Install BoldGrid Inspirations.
3. Use a connect key that has some image coins on it, or contact @jamesros161 if you need to get coins added for this test.
4. Replace an image on a page with a non-free image from the Connect Search. Ensure that the image gets cropped during the process. The cropping is what caused the issue before. 
5. Save the page, then go to Transactions > Cart / Checkout
6. Purchase the image.
7. Return to the page, and ensure that the image you purchased has been replaced on the page.