### PR TITLE
PX option is cut off from some popovers

### DIFF
--- a/assets/scss/builder/panel/_navigation.scss
+++ b/assets/scss/builder/panel/_navigation.scss
@@ -1,12 +1,16 @@
+.rtl {
+	.editor-panel .panel-body .customize {
+		.directional-control {
+			.units {
+				position: relative;
+				margin-right: 28px;
+			}
+		}
+	}
+}
 .editor-panel .panel-body .customize {
 	margin-left: 65px;
 	margin-right: 5px;
-	.directional-control {
-		.units {
-			position: relative;
-			margin-right: 28px;
-		}
-	}
 }
 
 .editor-panel .boldgrid-panel-nav__item:hover {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,7 +1158,7 @@
 
 "@boldgrid/controls@https://github.com/BoldGrid/controls#ppb-dev":
   version "0.13.1"
-  resolved "https://github.com/BoldGrid/controls#da576466d2cc5d0a845b1ecf156a065442991fa9"
+  resolved "https://github.com/BoldGrid/controls#a6387cb50574dc05a23b4d6c40522a1fa78852aa"
   dependencies:
     "@boldgrid/components" "^2.16.25"
     Buttons "https://github.com/BoldGrid/Buttons"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,7 +1158,7 @@
 
 "@boldgrid/controls@https://github.com/BoldGrid/controls#ppb-dev":
   version "0.13.1"
-  resolved "https://github.com/BoldGrid/controls#a6387cb50574dc05a23b4d6c40522a1fa78852aa"
+  resolved "https://github.com/BoldGrid/controls#3fa28216cc39b70212be6a21dff9550a89ac291a"
   dependencies:
     "@boldgrid/components" "^2.16.25"
     Buttons "https://github.com/BoldGrid/Buttons"


### PR DESCRIPTION
ISSUE: Resolves #533 

PROJECT: [PPB Issues > Current Release Cycle](https://github.com/orgs/BoldGrid/projects/14/views/11)

# PX option is cut off from some popovers #

## Test Files ##

[post-and-page-builder-1.26.2-issue-533.zip](https://github.com/BoldGrid/post-and-page-builder/files/14067331/post-and-page-builder-1.26.2-issue-533.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Open a panel with an advanced customize enabled ( ex: buttons or column shape ).
3. Click on the 'Customize' button on the bottom of the panel.
4. Navigate to the Padding, Margin, Border Radius and Border Width controls
5. Ensure that the PX unit isn't cut off, and appears as shown below:
![image](https://github.com/BoldGrid/post-and-page-builder/assets/49331357/dde61c73-c952-4de3-888f-432c214c7cb3)

