### PR TITLE
Conditionally load steller.js

### DIFF
--- a/includes/class-boldgrid-editor-assets.php
+++ b/includes/class-boldgrid-editor-assets.php
@@ -175,7 +175,13 @@ class Boldgrid_Editor_Assets {
 	/**
 	 * Check if the post content includes a string.
 	 *
+	 * This is used to determine if a script should be enqueued.
+	 *
 	 * @since 1.26.2
+	 *
+	 * @param string $string String to check for. Must be regex compatible.
+	 *
+	 * @return boolean Does the post content include the string?
 	 */
 	public function post_content_includes( $string ) {
 		global $post;

--- a/includes/class-boldgrid-editor-assets.php
+++ b/includes/class-boldgrid-editor-assets.php
@@ -173,22 +173,18 @@ class Boldgrid_Editor_Assets {
 	}
 
 	/**
-	 * Maybe Enqueue Animate.css
+	 * Check if the post content includes a string.
 	 *
-	 * Checks if post uses the animate.css or not.
-	 *
-	 * @since 1.21.0
-	 *
-	 * @return bool True if animate.css is to be enqueued.
+	 * @since 1.26.2
 	 */
-	public function maybe_enqueue_animate() {
+	public function post_content_includes( $string ) {
 		global $post;
 
 		if ( ! $post ) {
-			return true;
+			return false;
 		}
 
-		if ( preg_match( '/class=".*wow.*"/', $post->post_content ) ) {
+		if ( preg_match( '/' . $string . '/', $post->post_content ) ) {
 			return true;
 		} else {
 			return false;
@@ -203,9 +199,15 @@ class Boldgrid_Editor_Assets {
 	public function front_end() {
 		// Parallax.
 		// @TODO only enqueue if the user is using this.
-		wp_enqueue_script( 'boldgrid-parallax',
-			plugins_url( '/assets/js/jquery-stellar/jquery.stellar.js', BOLDGRID_EDITOR_ENTRY ),
-		array( 'jquery' ),BOLDGRID_EDITOR_VERSION, true );
+		if ( $this->post_content_includes( 'background-parallax' ) ) {
+			wp_enqueue_script(
+				'boldgrid-parallax',
+				plugins_url( '/assets/js/jquery-stellar/jquery.stellar.js', BOLDGRID_EDITOR_ENTRY ),
+				array( 'jquery' ),
+				BOLDGRID_EDITOR_VERSION,
+				true
+			);
+		}
 
 		wp_enqueue_script(
 			'boldgrid-editor-public', self::get_webpack_script( 'public' ),
@@ -227,7 +229,7 @@ class Boldgrid_Editor_Assets {
 		);
 
 		// Only enque the animate.css if it's needed.
-		if ( $this->maybe_enqueue_animate() ) {
+		if ( $this->post_content_includes( 'class=".*wow.*"' ) ) {
 			wp_enqueue_style(
 				'animatecss',
 				plugins_url( '/assets/css/animate.min.css', BOLDGRID_EDITOR_ENTRY ),


### PR DESCRIPTION
ISSUE: Resolves #517 

PROJECT: [PPB Issues](https://github.com/orgs/BoldGrid/projects/14/views/11)

# Conditionally load steller.js #

## Test Files ##

[post-and-page-builder-premium-1.1.4-issue-517.zip](https://github.com/BoldGrid/post-and-page-builder/files/14101657/post-and-page-builder-premium-1.1.4-issue-517.zip)

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. View a page that does NOT utilize the parallax background feature.
3. Use the Chrome Dev Tools to view the list of JS files loaded ( this can be done under the 'Network' tab of the dev tools )
4. Ensure that the file `jquery.stellar.js` is not loaded.
5. Edit the page to include a parallax background somewhere on the page.
6. Reload the page and ensure that the `jquery.stellar.js` file IS loaded and that the parallax effect works as expected.