### PR TITLE
redirect users from wp_block to bg_block

### DIFF
--- a/includes/gridblock/class-boldgrid-editor-gridblock-post.php
+++ b/includes/gridblock/class-boldgrid-editor-gridblock-post.php
@@ -1,23 +1,23 @@
 <?php
 /**
-* Class: Boldgrid_Editor_Gridblock_Post
-*
-* Manage GridBlock as a custom post type.
-*
-* @since      1.6
-* @package    Boldgrid_Editor
-* @subpackage Boldgrid_Editor_Gridblock
-* @author     BoldGrid <support@boldgrid.com>
-* @link       https://boldgrid.com
-*/
+ * Class: Boldgrid_Editor_Gridblock_Post
+ *
+ * Manage GridBlock as a custom post type.
+ *
+ * @since      1.6
+ * @package    Boldgrid_Editor
+ * @subpackage Boldgrid_Editor_Gridblock
+ * @author     BoldGrid <support@boldgrid.com>
+ * @link       https://boldgrid.com
+ */
 
 /**
  * Class: Boldgrid_Editor_Gridblock_Post
-*
-* Manage GridBlock as a custom post type.
-*
-* @since      1.6
-*/
+ *
+ * Manage GridBlock as a custom post type.
+ *
+ * @since      1.6
+ */
 class Boldgrid_Editor_Gridblock_Post {
 
 	/**
@@ -39,6 +39,8 @@ class Boldgrid_Editor_Gridblock_Post {
 	 * @since 1.7.0
 	 */
 	public function add_menu_items() {
+		global $submenu;
+
 		add_submenu_page(
 			'edit.php?post_type=bg_block',
 			__( 'All Pages', 'boldgrid-editor' ),
@@ -54,6 +56,32 @@ class Boldgrid_Editor_Gridblock_Post {
 			'edit_pages',
 			'post-new.php?post_type=page'
 		);
+
+		/*
+		 * WordPress 6.5 added a new subpage to the Appearance
+		 * menu item. This essentially allows users to create the
+		 * Gutenberg equivelant of a PPB Block. Since those are
+		 * not compatible with PPB, we are re-directing users to
+		 * the BG Blocks section where they can create Blocks.
+		 */
+		if ( ! isset( $submenu['themes.php'] ) ) {
+			return;
+		}
+
+		foreach ( $submenu['themes.php'] as $key => $item ) {
+			if ( 'edit.php?post_type=wp_block' === $item[2] ) {
+				remove_submenu_page( 'themes.php', 'edit.php?post_type=wp_block' );
+				add_submenu_page(
+					'themes.php',
+					__( 'Patterns', 'boldgrid-editor' ),
+					__( 'Patterns', 'boldgrid-editor' ),
+					'edit_posts',
+					'edit.php?post_type=bg_block',
+					'',
+					2
+				);
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
ISSUE: Resolves #579 

PROJECT: [PPB Issues](https://github.com/orgs/BoldGrid/projects/14/views/11?pane=issue&itemId=53752389)

# Redirect Users from wp_block to bg_block #

## Test Files ##

[post-and-page-builder-1.26.3-issue-579.zip](https://github.com/BoldGrid/post-and-page-builder/files/14576263/post-and-page-builder-1.26.3-issue-579.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Install WP Beta Tester plugin, and set to WP 6.5-rc.1 or newer.
3. Set the active theme to a 'classic' theme ( Anything that's NOT a block theme )
4. Go to the 'Appearance > Patterns' from the side admin menu.
5. Ensure that you are taken to `edit.php?post_type=bg_block` not `edit.php?post_type=wp_block`