### PR TITLE
don't show wp_block widget for non-admin users

### DIFF
--- a/components/class-boldgrid-components-shortcode.php
+++ b/components/class-boldgrid-components-shortcode.php
@@ -140,6 +140,15 @@ class Boldgrid_Components_Shortcode {
 			$widgets = $GLOBALS['wp_widget_factory']->widgets;
 
 			foreach( $widgets as $classname => $widget ) {
+				/*
+				 * If the user is not an admin, skip the 'block'
+				 * widget because it allows the users to add
+				 * arbitrary HTML and JavaScript.
+				 */
+				if ( ! current_user_can( 'manage_options' ) && 'block' === $widget->id_base ) {
+					continue;
+				}
+
 				if ( ! in_array( $widget->id_base, $this->config['skipped_widgets'] ) ) {
 					$name = 'wp_' . $widget->id_base;
 					$widget_config = $this->create_widget_config( $widget, $classname );


### PR DESCRIPTION
ISSUE: Resolves #580 
PROJECT: [PPB Issues](https://github.com/orgs/BoldGrid/projects/14/views/11?pane=issue&itemId=56499157)

# Don't Show wp_block Widget for non-admin users #

## Test Files ##

[post-and-page-builder-1.26.3-issue-580.zip](https://github.com/BoldGrid/post-and-page-builder/files/14619782/post-and-page-builder-1.26.3-issue-580.zip)

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Create a non-admin user, such as a contributor.
3. Login as the contributor user
4. Create a post, and make sure that the 'Block' widget is not shown when trying to add a component
5. Make sure that the 'Block' widget shows when logged in as an admin.