### PR TITLE
Fix link ui styling

### DIFF
--- a/assets/scss/builder/_tinymce.scss
+++ b/assets/scss/builder/_tinymce.scss
@@ -200,3 +200,14 @@ body.mce-fullscreen.boldgrid-zoomout {
 	}
 }
 
+.mce-inline-toolbar-grp.mce-container {
+	div.mce-flow-layout-item {
+		> div {
+			display: block;
+			.ui-autocomplete-input {
+				display: block;
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
ISSUE: Resolves #606 

# Fix Link UI Styling #

## Test Files ##

[post-and-page-builder-1.26.6-issue-606.zip](https://github.com/user-attachments/files/16088458/post-and-page-builder-1.26.6-issue-606.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Install WP 6.6-RC.2
3. Install Crio
4. Edit a page or post. 
5. Add a link using the in-editor link tool
![image](https://github.com/BoldGrid/post-and-page-builder/assets/49331357/211c2aed-84d6-4558-9b75-e4109d18ad36)
6. Ensure that the text label 'Paste URL or type to search' appears above the input bar, rather than to the side of it.
7. Ensure that when editing a link, that the link is shown above the edit buttons, and not beside it.

Incorrect: 
![image](https://github.com/BoldGrid/post-and-page-builder/assets/49331357/a63e0bb2-8a5a-4dcb-a61c-0c027e556096)

Correct:
![image](https://github.com/BoldGrid/post-and-page-builder/assets/49331357/d5a72f5b-2685-466e-b191-f4b740720f75)


Incorrect:
![image](https://github.com/BoldGrid/post-and-page-builder/assets/49331357/8b28d2e8-5657-4f4e-b07b-a5a26dc0d2a0)

Correct:
![image](https://github.com/BoldGrid/post-and-page-builder/assets/49331357/83e9a8f5-5f54-47ab-915e-24a62ecbe30c)
