### PR TITLE
Resolves Issue - Cannot create a button with the neutral background color

### DIFF
--- a/assets/js/builder/component/button/control.js
+++ b/assets/js/builder/component/button/control.js
@@ -221,7 +221,11 @@ BOLDGRID.EDITOR.CONTROLS = BOLDGRID.EDITOR.CONTROLS || {};
 					self.removeColorClasses();
 					$this.siblings().removeClass( 'selected' );
 					$this.addClass( 'selected' );
-					$target.addClass( 'btn-color-' + $this.attr( 'data-preset' ) );
+					if ( BoldgridEditor.is_crio && 'neutral' === $this.attr( 'data-preset' ) ) {
+						$target.addClass( 'btn-neutral-color' );
+					} else {
+						$target.addClass( 'btn-color-' + $this.attr( 'data-preset' ) );
+					}
 				}
 			);
 		},


### PR DESCRIPTION
ISSUE: Resolves #607 


# Cannot create a button with the neutral background color #

## Test Files ##

[post-and-page-builder-1.27.1-issue-607.zip](https://github.com/user-attachments/files/16997087/post-and-page-builder-1.27.1-issue-607.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Install Crio.
3. Add a button to a page, or modify an existing button ( note customizing buttons set to 'primary' or 'secondary' doesn't work at all, so it needs to be a different type of button, since 'primary' and 'secondary' override other settings.
4. Change the color to the neutral color ( 6th position in palette ) and make sure the button responds accordingly.
5. Change back to a different color, and ensure it responds accordingly.