### PR TITLE
Fix section divider colors on CPH & Sticky Header.

### DIFF
--- a/assets/js/public.js
+++ b/assets/js/public.js
@@ -490,9 +490,9 @@ class Public {
 			hasBgColor;
 
 		if ( 'bottom' === position && $boldgridSection.parent().is( '#masthead' ) ) {
-			$sibling = $( '#content' ).find( '.boldgrid-section' ).first();
+			$sibling = $( '#content main' ).find( '.boldgrid-section' ).first();
 		} else if ( 'top' === position && $boldgridSection.parent().is( '.bgtfw-footer' ) ) {
-			$sibling = $( '#content' ).find( '.boldgrid-section' ).last();
+			$sibling = $( '#content main' ).find( '.boldgrid-section' ).last();
 		} else if ( 0 === $sibling.length && 'top' === position ) {
 			hasBgColor = false;
 			hasBgColor = $header.find( '.boldgrid-section' ).last().css( 'background-color' );


### PR DESCRIPTION
ISSUE: Resolves #624 

# Fix section divider colors on CPH & Sticky Header #

## Test Files ##

[post-and-page-builder-1.27.2-issue-624.zip](https://github.com/user-attachments/files/17296989/post-and-page-builder-1.27.2-issue-624.zip)

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Install an inspiration with a section divider ( in the testing the DH Dog Care theme was used )
3. Add a sticky header in the customizer, but change the sticky header background to a color other than the color used by the section divider ( in this case the color set to color-2 )
4. Verify that the section divider keeps the correct color instead of taking the color of the sticky header.