### PR TITLE
don't show customize option for crio theme buttons

### DIFF
--- a/assets/js/builder/component/button/control.js
+++ b/assets/js/builder/component/button/control.js
@@ -481,6 +481,13 @@ BOLDGRID.EDITOR.CONTROLS = BOLDGRID.EDITOR.CONTROLS || {};
 					} );
 				}
 			} );
+
+			// Remove primary and secondary buttons from the list if Crio.
+			if ( BoldgridEditor.is_crio ) {
+				self.usedComponents = _.filter( self.usedComponents, function( item ) {
+					return -1 === item.classes.indexOf( 'button-primary' ) && -1 === item.classes.indexOf( 'button-secondary' );
+				} );
+			}
 		},
 
 		/**

--- a/assets/js/builder/component/button/control.js
+++ b/assets/js/builder/component/button/control.js
@@ -437,9 +437,20 @@ BOLDGRID.EDITOR.CONTROLS = BOLDGRID.EDITOR.CONTROLS || {};
 		 * @since 1.2.7
 		 */
 		toggleFooter: function() {
-			var $target = BG.Menu.getTarget( self );
+			var $target    = BG.Menu.getTarget( self ),
+				showFooter = false;
 
 			if ( $target.hasClass( 'btn' ) ) {
+				showFooter = true;
+			}
+
+			if ( BoldgridEditor.is_crio && 
+				( $target.hasClass( 'button-primary' ) || $target.hasClass( 'button-secondary' ) )
+			) {
+				showFooter = false;
+			}
+
+			if ( showFooter ) {
 				BG.Panel.showFooter();
 			} else {
 				BG.Panel.hideFooter();


### PR DESCRIPTION
ISSUE: Resolves #507 


# Don't show customize option for Crio Theme buttons #

## Test Files ##

[post-and-page-builder-1.27.4-issue-507.zip](https://github.com/user-attachments/files/18083028/post-and-page-builder-1.27.4-issue-507.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Install Crio
3. Add content that uses the primary and / or secondary button classes from Crio. Starter Content works for this.
4. Edit the page / post in PPB.
5. Click on a button that has the primary / secondary class, and click on the "Button Design" button in the top menu.
6. Ensure that the 'Customize Button' isn't shown in the footer of the Button Design panel.
7. Change the button to one of the "Sample Designs" or "My Designs" buttons if any exist
8. Ensure that the 'Customize Button' is now shown in the footer.