### PR TITLE
Fix narrow tables on mobile.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 	},
 	"dependencies": {
 		"@babel/preset-react": "^7.22.3",
-		"@boldgrid/components": "^2.16.31",
+		"@boldgrid/components": "^2.16.34",
 		"@boldgrid/controls": "https://github.com/BoldGrid/controls#ppb-dev",
 		"@boldgrid/fourpan": "^1.1.1",
 		"@wordpress/components": "^25.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,10 +1151,10 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@boldgrid/components@^2.16.2", "@boldgrid/components@^2.16.25", "@boldgrid/components@^2.16.31":
-  version "2.16.32"
-  resolved "https://registry.yarnpkg.com/@boldgrid/components/-/components-2.16.32.tgz#d4e69d3e4694007b92e657d867890cca1e1f391e"
-  integrity sha512-hHg4hECvGnpdL9SIm9AAY48LhVwIrDziKZ2Rnpx3N12btNyOJsPgvuHLqrs0v8F0JXgqpamI7yBDzG1zmVQ28A==
+"@boldgrid/components@^2.16.2", "@boldgrid/components@^2.16.25", "@boldgrid/components@^2.16.34":
+  version "2.16.34"
+  resolved "https://registry.yarnpkg.com/@boldgrid/components/-/components-2.16.34.tgz#14a30378cfdc75bb0694c4b6d3e3419701ed711b"
+  integrity sha512-oE0mQa1ZgIk2jSVN0ZPsdH6Yt81/j+94EdAvzh39NWAwzrnZTfWmF7bTHgxPeD1peWboaKKS8/Dqr5agTty4mw==
 
 "@boldgrid/controls@https://github.com/BoldGrid/controls#ppb-dev":
   version "0.13.1"


### PR DESCRIPTION
ISSUE: Resolves #604 

# Fix narrow tables on mobile #

## Test Files ##

[post-and-page-builder-1.27.4-issue-604.zip](https://github.com/user-attachments/files/18084665/post-and-page-builder-1.27.4-issue-604.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Use Crio, open the Customizer and navigate to Design > Pages > Container and set to Full Width
3. Create a page and add a fixed width section (just container class, not container-fluid)
4. Add a table and toggle the setting for Responsive Table on tablet / phones. Ensure that the table is the only thing in the section.
5. Preview the page and drag the screen in so it's phone view narrow
6. Ensure that the table is taking up the full width of the container.
7. Test on an iOS device as well, as this issue was originally by a change made to fix tables being too wide on iOS devices.